### PR TITLE
Use cs mapping to determine entity table names.

### DIFF
--- a/EFDocumentationGenerator.Package/EFDocumentationGenerator.Package.csproj
+++ b/EFDocumentationGenerator.Package/EFDocumentationGenerator.Package.csproj
@@ -23,6 +23,9 @@
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <DeployExtension Condition="'$(AppVeyor)' != ''">False</DeployExtension>
+    <StartAction>Program</StartAction>
+    <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/EFDocumentationGenerator/DatabaseDocumentationSource.cs
+++ b/EFDocumentationGenerator/DatabaseDocumentationSource.cs
@@ -27,20 +27,10 @@ namespace DocumentationGenerator
         /// <summary>
         /// Initializes a new <see cref="DatabaseDocumentationSource"/>.
         /// </summary>
-        /// <param name="connectionString">The database connection string</param>
-        public DatabaseDocumentationSource(string connectionString)
-            : this(connectionString, cs => new SqlConnection(cs))
+        /// <param name="connection">The database connection.</param>
+        public DatabaseDocumentationSource(IDbConnection connection)
         {
-        }
-
-        /// <summary>
-        /// Initializes a new <see cref="DatabaseDocumentationSource"/>.
-        /// </summary>
-        /// <param name="connectionString">The database connection string</param>
-        /// <param name="connectionFactory">Creates database connections from a connection string</param>
-        public DatabaseDocumentationSource(string connectionString, Func<string, IDbConnection> connectionFactory)
-        {
-            _connection = connectionFactory(connectionString);
+            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
             _connection.Open();
         }
 
@@ -79,7 +69,7 @@ namespace DocumentationGenerator
             }
         }
 
-        private static string GetSecondLevelType(EntityPropertyType propertyType) => 
+        private static string GetSecondLevelType(EntityPropertyType propertyType) =>
             propertyType == EntityPropertyType.Property ? "'column'" : "'constraint'";
 
         private readonly IDbConnection _connection;

--- a/EFDocumentationGenerator/EFDocumentationGenerator.csproj
+++ b/EFDocumentationGenerator/EFDocumentationGenerator.csproj
@@ -125,8 +125,10 @@
     <Compile Include="Diagnostics\IOutputPaneProvider.cs" />
     <Compile Include="Diagnostics\OutputPaneProvider.cs" />
     <Compile Include="Diagnostics\OutputWindowLogger.cs" />
+    <Compile Include="EntityDataModel.cs" />
     <Compile Include="EntityProperty.cs" />
     <Compile Include="EntityPropertyType.cs" />
+    <Compile Include="EntityType.cs" />
     <Compile Include="EnvDTEConstants.cs" />
     <Compile Include="ErrorListAdapter.cs" />
     <Compile Include="IModelDocumentationUpdater.cs" />

--- a/EFDocumentationGenerator/EntityDataModel.cs
+++ b/EFDocumentationGenerator/EntityDataModel.cs
@@ -48,11 +48,14 @@ namespace DocumentationGenerator
             // that is being mapped is specified by the StoreEntitySet attribute of the 
             // child MappingFragment element.
             _mappings = edmxDocument.Cs().Descendants("EntitySetMapping")
-                                         .Select(es => es.Cs().Element("EntityTypeMapping"))
-                                         .ToDictionary(et => et.Attribute("TypeName").Value,
+                                         .SelectMany(es => es.Cs().Elements("EntityTypeMapping"))
+                                         .ToDictionary(et => Sanitize(et.Attribute("TypeName").Value),
                                                        et => et.Cs().Element("MappingFragment")
                                                                     .Attribute("StoreEntitySet").Value);
         }
+
+        private static string Sanitize(string typeName) => typeName.Replace("IsTypeOf(", string.Empty)
+                                                                   .Replace(")", string.Empty);
 
         /// <summary>
         /// The entities in the conceptual data model.

--- a/EFDocumentationGenerator/EntityDataModel.cs
+++ b/EFDocumentationGenerator/EntityDataModel.cs
@@ -1,0 +1,75 @@
+﻿//  Entity Designer Documentation Generator
+//  Copyright 2017 Matthew Hamilton - matthamilton@live.com
+// 
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+// 
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using System;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentationGenerator.Utilities;
+using System.Collections.Generic;
+
+namespace DocumentationGenerator
+{
+    /// <summary>
+    /// Represents the contents of an EDMX file.
+    /// </summary>
+    public class EntityDataModel
+    {
+        private readonly INamespacedOperations _conceptualModel;
+        private readonly string _conceptualTypeNamespace;
+        private readonly IDictionary<string, string> _mappings;
+
+        /// <summary>
+        /// Initializes a new <see cref="EntityDataModel"/>.
+        /// </summary>
+        /// <param name="edmxDocument">The edmx file containing the model.</param>
+        public EntityDataModel(XDocument edmxDocument)
+        {
+            _conceptualModel = edmxDocument?.Edm() ?? throw new ArgumentNullException(nameof(edmxDocument));
+
+            _conceptualTypeNamespace = _conceptualModel.Descendants("Schema")
+                                                       .Single()
+                                                       .Attribute("Namespace").Value;
+
+            // The conceptual model entity type that is being mapped is specified by the
+            // TypeName attribute of the EntityTypeMapping element. The table or view 
+            // that is being mapped is specified by the StoreEntitySet attribute of the 
+            // child MappingFragment element.
+            _mappings = edmxDocument.Cs().Descendants("EntitySetMapping")
+                                         .Select(es => es.Cs().Element("EntityTypeMapping"))
+                                         .ToDictionary(et => et.Attribute("TypeName").Value,
+                                                       et => et.Cs().Element("MappingFragment")
+                                                                    .Attribute("StoreEntitySet").Value);
+        }
+
+        /// <summary>
+        /// The entities in the conceptual data model.
+        /// </summary>
+        public IEnumerable<EntityType> Entities => _conceptualModel.Descendants("EntityType")
+                                                                   .Select(CreateEntity)
+                                                                   .Where(e => e != null);
+
+        private EntityType CreateEntity(XElement element)
+        {
+            var conceptualName = $"{_conceptualTypeNamespace}.{element.Attribute("Name").Value}";
+            if (!_mappings.TryGetValue(conceptualName, out var storageName))
+                return null;
+
+            return new EntityType(_conceptualModel,
+                                  element,
+                                  conceptualName,
+                                  storageName);
+        }
+    }
+}

--- a/EFDocumentationGenerator/EntityDataModel.cs
+++ b/EFDocumentationGenerator/EntityDataModel.cs
@@ -22,7 +22,8 @@ using System.Collections.Generic;
 namespace DocumentationGenerator
 {
     /// <summary>
-    /// Represents the contents of an EDMX file.
+    /// Represents the contents of an EDMX file. It is essentially a wrapper
+    /// around an EDMX file.
     /// </summary>
     public class EntityDataModel
     {

--- a/EFDocumentationGenerator/EntityProperty.cs
+++ b/EFDocumentationGenerator/EntityProperty.cs
@@ -13,32 +13,61 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+using DocumentationGenerator.Utilities;
+using System;
+using System.Xml.Linq;
+
 namespace DocumentationGenerator
 {
-	/// <summary>
-	/// Represents an entity property.
-	/// </summary>
-	public class EntityProperty
-	{
-		/// <summary>
-		/// Initializes a new <see cref="EntityProperty"/>.
-		/// </summary>
-		/// <param name="name">The property name</param>
-		/// <param name="type">The property type</param>
-		public EntityProperty(string name, EntityPropertyType type)
-		{
-			Name = name;
-			Type = type;
-		}
+    /// <summary>
+    /// Represents an entity property.
+    /// </summary>
+    public class EntityProperty
+    {
+        private readonly INamespacedOperations _conceptualModel;
+        private readonly XElement _element;
 
-		/// <summary>
-		/// The property name.
-		/// </summary>
-		public string Name { get; }
+        /// <summary>
+        /// Initializes a new <see cref="EntityProperty"/>.
+        /// </summary>
+        /// <param name="conceptualModel">The model a property belongs to.</param>
+        /// <param name="element">The backing property element.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="type">The property type.</param>
+        public EntityProperty(INamespacedOperations conceptualModel, XElement element, string name, EntityPropertyType type)
+        {
+            _conceptualModel = conceptualModel ?? throw new ArgumentNullException(nameof(conceptualModel));
+            _element = element;
+            Name = name;
+            Type = type;
+        }
 
-		/// <summary>
-		/// The property type.
-		/// </summary>
-		public EntityPropertyType Type { get; }
-	}
+        /// <summary>
+        /// The property name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The property type.
+        /// </summary>
+        public EntityPropertyType Type { get; }
+
+        /// <summary>
+        /// Updates the documentation for a property.
+        /// </summary>
+        /// <param name="documentation"></param>
+        public void UpdateDocumentation(string documentation)
+        {
+            if (documentation == null)
+                return;
+
+            var fixedDocumentation = documentation.Trim();
+
+            // Remove existing documentation.
+            _element.Edm().Descendants("Documentation").Remove();
+
+            _element.AddFirst(new XElement(XName.Get("Documentation", _conceptualModel.Namespace),
+                                           new XElement(XName.Get("Summary", _conceptualModel.Namespace), fixedDocumentation)));
+        }
+    }
 }

--- a/EFDocumentationGenerator/EntityType.cs
+++ b/EFDocumentationGenerator/EntityType.cs
@@ -1,0 +1,105 @@
+﻿//  Entity Designer Documentation Generator
+//  Copyright 2017 Matthew Hamilton - matthamilton@live.com
+// 
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+// 
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using System;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentationGenerator.Utilities;
+using System.Collections.Generic;
+
+namespace DocumentationGenerator
+{
+    /// <summary>
+    /// Represents an entity type.
+    /// </summary>
+    public class EntityType
+    {
+        private readonly INamespacedOperations _conceptualModel;
+        private readonly XElement _element;
+
+        /// <summary>
+        /// Initialized a new <see cref="EntityType"/>.
+        /// </summary>
+        /// <param name="conceptualModel">The conceptual model the entity belongs to.</param>
+        /// <param name="element">The backing entity type element.</param>
+        /// <param name="conceptualName">The name of an entity in the conceptual model.</param>
+        /// <param name="storageName">The name of an entity in the storage model.</param>
+        public EntityType(INamespacedOperations conceptualModel, XElement element, string conceptualName, string storageName)
+        {
+            _conceptualModel = conceptualModel ?? throw new ArgumentNullException(nameof(conceptualModel));
+            _element = element ?? throw new ArgumentNullException(nameof(element));
+
+            ConceptualName = conceptualName ?? throw new ArgumentNullException(nameof(conceptualName));
+            StorageName = storageName ?? throw new ArgumentNullException(nameof(storageName));
+        }
+
+        /// <summary>
+        /// The properties of an entity.
+        /// </summary>
+        public IEnumerable<EntityProperty> Properties => _element.Edm().Descendants("Property")
+                                                                       .Select(CreateProperty)
+                                                                       .Concat(
+                                                         _element.Edm().Descendants("NavigationProperty")
+                                                                       .Select(CreateNavProperty));
+        /// <summary>
+        /// The name of an entity in the conceptual model.
+        /// </summary>
+        public string ConceptualName { get; }
+
+        /// <summary>
+        /// The name of an entity in the storage model.
+        /// </summary>
+        public string StorageName { get; }
+
+        private EntityProperty CreateProperty(XElement element)
+        {
+            return new EntityProperty(_conceptualModel,
+                                      element,
+                                      element.Attribute("Name").Value,
+                                      EntityPropertyType.Property);
+        }
+
+        private EntityProperty CreateNavProperty(XElement element)
+        {
+            var relationship = element.Attribute("Relationship").Value;
+            var association = _conceptualModel
+                .Descendants("AssociationSet")
+                .Single(ae => ae.Attribute("Association").Value == relationship);
+
+            return new EntityProperty(_conceptualModel,
+                                      element,
+                                      association.Attribute("Name").Value,
+                                      EntityPropertyType.NavigationProperty);
+        }
+
+        /// <summary>
+        /// Updates the documentation for an entity.
+        /// </summary>
+        /// <param name="documentation"></param>
+        public void UpdateDocumentation(string documentation)
+        {
+            if (documentation == null)
+                return;
+
+            var fixedDocumentation = documentation.Trim();
+
+            // Remove existing documentation.
+            _element.Edm().Descendants("Documentation").Remove();
+
+            _element.AddFirst(new XElement(XName.Get("Documentation", _conceptualModel.Namespace),
+                                           new XElement(XName.Get("Summary", _conceptualModel.Namespace), fixedDocumentation)));
+        }
+    }
+}

--- a/EFDocumentationGenerator/ModelDocumentationUpdater.cs
+++ b/EFDocumentationGenerator/ModelDocumentationUpdater.cs
@@ -13,10 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-using System;
-using System.Linq;
 using System.Xml.Linq;
-using DocumentationGenerator.Utilities;
 
 namespace DocumentationGenerator
 {
@@ -42,80 +39,18 @@ namespace DocumentationGenerator
         /// <param name="modelDocument">An .edmx XML document to update</param>
         public void UpdateDocumentation(XDocument modelDocument)
         {
-            var conceptualModel = modelDocument.Edm();
-            var conceptualTypeNamespace = conceptualModel.Descendants("Schema")
-                                                         .Single()
-                                                         .Attribute("Namespace").Value;
-
-            // The conceptual model entity type that is being mapped is specified by the
-            // TypeName attribute of the EntityTypeMapping element. The table or view 
-            // that is being mapped is specified by the StoreEntitySet attribute of the 
-            // child MappingFragment element.
-            var mappings = modelDocument.Cs().Descendants("EntitySetMapping")
-                                             .Select(es => es.Cs().Element("EntityTypeMapping"))
-                                             .ToDictionary(et => et.Attribute("TypeName").Value, 
-                                                           et => et.Cs().Element("MappingFragment")
-                                                                        .Attribute("StoreEntitySet").Value);
-
-            foreach (var entityType in conceptualModel.Descendants("EntityType").ToList())
+            var dataModel = new EntityDataModel(modelDocument);
+            foreach (var entity in dataModel.Entities)
             {
-                var conceptualName = entityType.Attribute("Name").Value;
+                var entityDocumentation = _documentationSource.GetDocumentation(entity.StorageName);
+                entity.UpdateDocumentation(entityDocumentation);
 
-                if (!mappings.TryGetValue($"{conceptualTypeNamespace}.{conceptualName}", out var storageName))
-                    continue;
-
-                UpdateNodeDocumentation(entityType, conceptualModel.Namespace, 
-                    _documentationSource.GetDocumentation(storageName));
-
-                var properties =
-                        entityType.Edm().Descendants("Property")
-                                  .Select(e => new
-                                  {
-                                      Element = e,
-                                      Property = new EntityProperty(
-                                                   e.Attribute("Name").Value,
-                                                   EntityPropertyType.Property)
-                                  })
-                    .Concat(
-                        entityType.Edm().Descendants("NavigationProperty")
-                                  .Select(e => new
-                                  {
-                                      Element = e,
-                                      Property = CreateNavProperty(e, modelDocument)
-                                  }));
-
-                foreach (var property in properties)
+                foreach (var property in entity.Properties)
                 {
-                    UpdateNodeDocumentation(property.Element, conceptualModel.Namespace,
-                        _documentationSource.GetDocumentation(storageName, property.Property));
+                    var propertyDocumentation = _documentationSource.GetDocumentation(entity.StorageName, property);
+                    property.UpdateDocumentation(propertyDocumentation);
                 }
             }
-        }
-
-        private static void UpdateNodeDocumentation(XContainer element, string edmNamespace, string documentation)
-        {
-            if (String.IsNullOrWhiteSpace(documentation))
-                return;
-
-            var fixedDocumentation = documentation.Trim();
-
-            // Remove existing documentation.
-            element.Edm().Descendants("Documentation").Remove();
-
-            element.AddFirst(new XElement(XName.Get("Documentation", edmNamespace),
-                                          new XElement(XName.Get("Summary", edmNamespace), fixedDocumentation)));
-        }
-
-        private static EntityProperty CreateNavProperty(XElement element, XContainer document)
-        {
-            var relationship = element.Attribute("Relationship").Value;
-            var association = document.Edm()
-                .Descendants("AssociationSet")
-                .Single(ae => ae.Attribute("Association").Value == relationship);
-
-            return new EntityProperty(
-                association.Attribute("Name").Value,
-                EntityPropertyType.NavigationProperty);
         }
 
         private readonly IDocumentationSource _documentationSource;

--- a/EFDocumentationGenerator/ModelGenerationExtension.cs
+++ b/EFDocumentationGenerator/ModelGenerationExtension.cs
@@ -45,8 +45,8 @@ namespace DocumentationGenerator
         public ModelGenerationExtension(ILogger logger, IConnectionStringLocator connectionStringLocator, IReadOnlyList<ErrorItem> errorList)
             : this(logger,
                    connectionStringLocator,
-                   connectionString => new DatabaseDocumentationSource(connectionString),
-                   source => new ModelDocumentationUpdater(source), 
+                   connectionString => new DatabaseDocumentationSource(new SqlConnection(connectionString)),
+                   source => new ModelDocumentationUpdater(source),
                    errorList)
         {
         }

--- a/EFDocumentationGenerator/Utilities/XContainerExtensions.cs
+++ b/EFDocumentationGenerator/Utilities/XContainerExtensions.cs
@@ -24,17 +24,30 @@ namespace DocumentationGenerator.Utilities
 	/// </summary>
 	internal static class XContainerExtensions
 	{
-		/// <summary>
-		/// Provides access to edm schema XML namespace-specific operations.
-		/// </summary>
-		public static INamespacedOperations Edm(this XContainer element) => new NamespacedOperations(element, EdmNamespace);
+        private const string SsdlNamespace = "http://schemas.microsoft.com/ado/2009/11/edm/ssdl";
+        private const string EdmNamespace = "http://schemas.microsoft.com/ado/2009/11/edm";
+        private const string CsNamespace = "http://schemas.microsoft.com/ado/2009/11/mapping/cs";
 
-	    private const string EdmNamespace = "http://schemas.microsoft.com/ado/2009/11/edm";
+        /// <summary>
+        /// Provides access to Storage Model (SSDL) schema XML namespace-specific operations.
+        /// </summary>
+        public static INamespacedOperations Ssdl(this XContainer element) => new NamespacedOperations(element, SsdlNamespace);
 
-		/// <summary>
-		/// Provides access to XML namespace-specific operations.
-		/// </summary>
-		public interface INamespacedOperations
+        /// <summary>
+        /// Provides access to Conceptual Model (EDM) schema XML namespace-specific operations.
+        /// </summary>
+        public static INamespacedOperations Edm(this XContainer element) => new NamespacedOperations(element, EdmNamespace);
+
+        /// <summary>
+        /// Provides access to Conceptual-Storage Mapping schema XML namespace-specific operations.
+        /// </summary>
+        public static INamespacedOperations Cs(this XContainer element) => new NamespacedOperations(element, CsNamespace);
+
+
+        /// <summary>
+        /// Provides access to XML namespace-specific operations.
+        /// </summary>
+        public interface INamespacedOperations
 		{
 			/// <summary>
 			/// Returns the Descendant <see cref="XElement"/>s with the passed in names from the EDM namespace 
@@ -91,8 +104,8 @@ namespace DocumentationGenerator.Utilities
 		    /// <see cref="INamespacedOperations.Elements"/>
 			public IEnumerable<XElement> Elements(string name) => _element.Elements(XName.Get(name, Namespace));
 
-		    /// <see cref="INamespacedOperations.Namespace"/>
-			public string Namespace { get; }
+            /// <see cref="INamespacedOperations.Namespace"/>
+            public string Namespace { get; }
 
 			private readonly XContainer _element;
 		}

--- a/EFDocumentationGenerator/Utilities/XContainerExtensions.cs
+++ b/EFDocumentationGenerator/Utilities/XContainerExtensions.cs
@@ -19,10 +19,53 @@ using System.Xml.Linq;
 
 namespace DocumentationGenerator.Utilities
 {
-	/// <summary>
-	/// Provides extension methods for <see cref="XElement"/>s.
-	/// </summary>
-	internal static class XContainerExtensions
+    /// <summary>
+    /// Provides access to XML namespace-specific operations.
+    /// </summary>
+    public interface INamespacedOperations
+    {
+        /// <summary>
+        /// Returns the Descendant <see cref="XElement"/>s with the passed in names from the EDM namespace 
+        /// as an <see cref="IEnumerable{XElement}"/>
+        /// </summary> 
+        /// <param name="name">The name to match against descendant <see cref="XElement"/>s.</param>
+        /// <returns>An <see cref="IEnumerable"/> of <see cref="XElement"/></returns> 
+        IEnumerable<XElement> Descendants(string name);
+
+        /// <summary>
+        /// Returns the child element with the specified name or null if there is no matching child element. 
+        /// <seealso cref="XContainer.Elements()"/>
+        /// </summary> 
+        /// <param name="name"> 
+        /// The element name to match against this <see cref="XContainer"/>'s child elements.
+        /// </param> 
+        /// <returns>
+        /// An <see cref="XElement"/> child that matches the name passed in, or null.
+        /// </returns>
+        XElement Element(string name);
+
+        /// <summary>
+        /// Returns the child elements of an <see cref="XContainer"/> that match the name passed in.
+        /// </summary> 
+        /// <param name="name">
+        /// The element name to match against the <see cref="XElement"/> children of this <see cref="XContainer"/>. 
+        /// </param> 
+        /// <returns>
+        /// An <see cref="IEnumerable"/> of <see cref="XElement"/> children of this <see cref="XContainer"/> that have 
+        /// a matching name.
+        /// </returns>
+        IEnumerable<XElement> Elements(string name);
+
+        /// <summary>
+        /// The XML namespace a set of operations are for.
+        /// </summary>
+        string Namespace { get; }
+    }
+
+    /// <summary>
+    /// Provides extension methods for <see cref="XElement"/>s.
+    /// </summary>
+    internal static class XContainerExtensions
 	{
         private const string SsdlNamespace = "http://schemas.microsoft.com/ado/2009/11/edm/ssdl";
         private const string EdmNamespace = "http://schemas.microsoft.com/ado/2009/11/edm";
@@ -42,50 +85,6 @@ namespace DocumentationGenerator.Utilities
         /// Provides access to Conceptual-Storage Mapping schema XML namespace-specific operations.
         /// </summary>
         public static INamespacedOperations Cs(this XContainer element) => new NamespacedOperations(element, CsNamespace);
-
-
-        /// <summary>
-        /// Provides access to XML namespace-specific operations.
-        /// </summary>
-        public interface INamespacedOperations
-		{
-			/// <summary>
-			/// Returns the Descendant <see cref="XElement"/>s with the passed in names from the EDM namespace 
-			/// as an <see cref="IEnumerable{XElement}"/>
-			/// </summary> 
-			/// <param name="name">The name to match against descendant <see cref="XElement"/>s.</param>
-			/// <returns>An <see cref="IEnumerable"/> of <see cref="XElement"/></returns> 
-			IEnumerable<XElement> Descendants(string name);
-
-			/// <summary>
-			/// Returns the child element with the specified name or null if there is no matching child element. 
-			/// <seealso cref="XContainer.Elements()"/>
-			/// </summary> 
-			/// <param name="name"> 
-			/// The element name to match against this <see cref="XContainer"/>'s child elements.
-			/// </param> 
-			/// <returns>
-			/// An <see cref="XElement"/> child that matches the name passed in, or null.
-			/// </returns>
-			XElement Element(string name);
-
-			/// <summary>
-			/// Returns the child elements of an <see cref="XContainer"/> that match the name passed in.
-			/// </summary> 
-			/// <param name="name">
-			/// The element name to match against the <see cref="XElement"/> children of this <see cref="XContainer"/>. 
-			/// </param> 
-			/// <returns>
-			/// An <see cref="IEnumerable"/> of <see cref="XElement"/> children of this <see cref="XContainer"/> that have 
-			/// a matching name.
-			/// </returns>
-			IEnumerable<XElement> Elements(string name);
-
-			/// <summary>
-			/// The XML namespace a set of operations are for.
-			/// </summary>
-			string Namespace { get; }
-		}
 
 		private class NamespacedOperations : INamespacedOperations
 		{

--- a/Tests.Unit/EntityDocExtension/DatabaseDocumentationSourceTests.cs
+++ b/Tests.Unit/EntityDocExtension/DatabaseDocumentationSourceTests.cs
@@ -15,7 +15,7 @@ namespace Tests.Unit.EntityDocExtension
 		    _connection.Setup(c => c.CreateCommand())
 		               .Returns(_command.Object);
 
-			_underTest = new DatabaseDocumentationSource("connectionString", _ => _connection.Object);
+			_underTest = new DatabaseDocumentationSource(_connection.Object);
 		}
 
 		[Fact]

--- a/Tests.Unit/EntityDocExtension/EdmxFixture.cs
+++ b/Tests.Unit/EntityDocExtension/EdmxFixture.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+using System.Xml.Linq;
+
+namespace Tests.Unit.EntityDocExtension
+{
+    public class EdmxFixture
+    {
+        public EdmxFixture()
+        {
+            using (var edmxStream = GetType().Assembly.GetManifestResourceStream("Tests.Unit.EntityDocExtension.TestModel.xml"))
+            using (var reader = new StreamReader(edmxStream))
+            {
+                Document = XDocument.Load(reader);
+            }
+        }
+
+        public XDocument Document { get; }
+    }
+}

--- a/Tests.Unit/EntityDocExtension/ModelDocumentationUpdaterTests.cs
+++ b/Tests.Unit/EntityDocExtension/ModelDocumentationUpdaterTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using DocumentationGenerator;
@@ -9,10 +8,12 @@ using Xunit;
 
 namespace Tests.Unit.EntityDocExtension
 {
-    public class ModelDocumentationUpdaterTests
+    public class ModelDocumentationUpdaterTests : IClassFixture<EdmxFixture>
     {
-        public ModelDocumentationUpdaterTests()
+        public ModelDocumentationUpdaterTests(EdmxFixture edmx)
         {
+            _edmx = edmx;
+
             _docSource.Setup(s => s.GetDocumentation(It.IsAny<string>(), It.IsAny<EntityProperty>()))
                       .Returns((string entityName, EntityProperty property) =>
                           _documentation[(entityName, property?.Name)]);
@@ -29,19 +30,17 @@ namespace Tests.Unit.EntityDocExtension
                 { ("FirstTable", null),             "FirstTable_Summary" },
                 { ("FirstTable", "FirstTableID"),   "FirstTableID_Summary" },
                 { ("FirstTable", "DateTimeColumn"), "DateTimeColumn_Summary" },
-                { ("SecondTable", null),            "SecondTable_Summary" },
-                { ("SecondTable", "SecondTableID"), "SecondTableID_Summary" },
-                { ("SecondTable", "StringColumn"),  "StringColumn_Summary" },
-                { ("SecondTable", "IntegerColumn"), "IntegerColumn_Summary" },
-                { ("SecondTable", "FK_FirstTable_Order_FirstTableID"), "ForeignKey_Summary" }
+                { ("SecondTables", null),            "SecondTable_Summary" },
+                { ("SecondTables", "SecondTableID"), "SecondTableID_Summary" },
+                { ("SecondTables", "StringColumn"),  "StringColumn_Summary" },
+                { ("SecondTables", "IntegerColumn"), "IntegerColumn_Summary" },
+                { ("SecondTables", "FK_FirstTable_Order_FirstTableID"), "ForeignKey_Summary" }
             };
 
-            var edmxDocument = XDocument.Load(new StringReader(Edmx));
-
             // Act.
-            _underTest.UpdateDocumentation(edmxDocument);
+            _underTest.UpdateDocumentation(_edmx.Document);
 
-            var entities = edmxDocument.Edm().Descendants("EntityType").ToList();
+            var entities = _edmx.Document.Edm().Descendants("EntityType").ToList();
 
             // Assert.
             Assert.NotEmpty(entities);
@@ -56,44 +55,14 @@ namespace Tests.Unit.EntityDocExtension
             Assert.Equal("ForeignKey_Summary", GetSummary(entities.Last().Edm().Element("NavigationProperty")));
         }
 
-        private static string GetSummary(XElement element)
-        {
-            return element.Edm().Element("Documentation").Edm().Element("Summary").Value;
-        }
+        private static string GetSummary(XElement element) => element.Edm().Element("Documentation")
+                                                                     .Edm().Element("Summary").Value;
 
         private readonly ModelDocumentationUpdater _underTest;
 
         private IDictionary<(string, string), string> _documentation;
         private readonly Mock<IDocumentationSource> _docSource = new Mock<IDocumentationSource>();
 
-        private const string Edmx =
-@"<?xml version='1.0' encoding='utf-8'?>
-<edmx:Edmx Version='3.0' xmlns:edmx='http://schemas.microsoft.com/ado/2009/11/edmx'>
-  <edmx:Runtime>
-    <edmx:ConceptualModels>
-      <Schema Namespace='TestModel' xmlns:annotation='http://schemas.microsoft.com/ado/2009/02/edm/annotation' 
-                                      xmlns:p1='http://schemas.microsoft.com/ado/2009/02/edm/annotation' 
-                                      xmlns='http://schemas.microsoft.com/ado/2009/11/edm'>
-        <AssociationSet Name='FK_FirstTable_Order_FirstTableID' Association='TestModel.FK_FirstTable_Order_FirstTableID'/>
-        <EntityType Name='FirstTable'>
-            <Key>
-            <PropertyRef Name='FirstTableID' />
-            </Key>
-            <Property Name='FirstTableID' Type='Int32' Nullable='false' p1:StoreGeneratedPattern='Identity'/>
-            <Property Name='DateTimeColumn' Type='DateTime' Nullable='false'/>
-        </EntityType>
-        <EntityType Name='SecondTable'>
-            <Key>
-            <PropertyRef Name='SecondTableID' />
-            </Key>
-            <Property Name='SecondTableID' Type='Int32' Nullable='false' p1:StoreGeneratedPattern='Identity'/>
-            <Property Name='StringColumn' Type='String' Nullable='false'/>
-            <Property Name='IntegerColumn' Type='Int32'/>
-            <NavigationProperty Name='FirstTable' Relationship='TestModel.FK_FirstTable_Order_FirstTableID'/>
-        </EntityType>
-      </Schema>
-    </edmx:ConceptualModels>
-  </edmx:Runtime>
-</edmx:Edmx>";
+        private readonly EdmxFixture _edmx;
     }
 }

--- a/Tests.Unit/EntityDocExtension/TestModel.xml
+++ b/Tests.Unit/EntityDocExtension/TestModel.xml
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="3.0" xmlns:edmx="http://schemas.microsoft.com/ado/2009/11/edmx">
+  <edmx:Runtime>
+    <edmx:ConceptualModels>
+      <Schema Namespace="TestModel" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+                                    xmlns:p1="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+                                    xmlns="http://schemas.microsoft.com/ado/2009/11/edm">
+        <EntityContainer Name="TestModelEntities">
+          <EntitySet Name="FirstTable" EntityType="TestModel.FirstTable" />
+          <EntitySet Name="SecondTables" EntityType="TestModel.SecondTable" />
+          <AssociationSet Name="FK_FirstTable_Order_FirstTableID" Association="TestModel.FK_FirstTable_Order_FirstTableID"/>
+        </EntityContainer>
+        <EntityType Name="FirstTable">
+          <Key>
+            <PropertyRef Name="FirstTableID" />
+          </Key>
+          <Property Name="FirstTableID" Type="Int32" Nullable="false" p1:StoreGeneratedPattern="Identity"/>
+          <Property Name="DateTimeColumn" Type="DateTime" Nullable="false"/>
+        </EntityType>
+        <EntityType Name="SecondTable">
+          <Key>
+            <PropertyRef Name="SecondTableID" />
+          </Key>
+          <Property Name="SecondTableID" Type="Int32" Nullable="false" p1:StoreGeneratedPattern="Identity"/>
+          <Property Name="StringColumn" Type="String" Nullable="false"/>
+          <Property Name="IntegerColumn" Type="Int32"/>
+          <NavigationProperty Name="FirstTable" Relationship="TestModel.FK_FirstTable_Order_FirstTableID"/>
+        </EntityType>
+      </Schema>
+    </edmx:ConceptualModels>
+    <edmx:Mappings>
+      <Mapping Space="C-S" xmlns="http://schemas.microsoft.com/ado/2009/11/mapping/cs">
+        <EntityContainerMapping StorageEntityContainer="TestModelsStoreContainer" CdmEntityContainer="TestModelEntities">
+          <EntitySetMapping Name="FirstTable">
+            <EntityTypeMapping TypeName="TestModel.FirstTable">
+              <MappingFragment StoreEntitySet="FirstTable">
+                <ScalarProperty Name="FirstTableID" ColumnName="FirstTableID" />
+                <ScalarProperty Name="DateTimeColumn" ColumnName="DateTimeColumn" />
+              </MappingFragment>
+            </EntityTypeMapping>
+          </EntitySetMapping>
+          <EntitySetMapping Name="SecondTables">
+            <EntityTypeMapping TypeName="TestModel.SecondTable">
+              <MappingFragment StoreEntitySet="SecondTables">
+                <ScalarProperty Name="SecondTableID" ColumnName="SecondTableID" />
+                <ScalarProperty Name="StringColumn" ColumnName="StringColumn" />
+                <ScalarProperty Name="IntegerColumn" ColumnName="IntegerColumn" />
+              </MappingFragment>
+            </EntityTypeMapping>
+          </EntitySetMapping>
+        </EntityContainerMapping>
+      </Mapping>
+    </edmx:Mappings>
+  </edmx:Runtime>
+</edmx:Edmx>

--- a/Tests.Unit/EntityDocExtension/TestModel.xml
+++ b/Tests.Unit/EntityDocExtension/TestModel.xml
@@ -5,49 +5,75 @@
       <Schema Namespace="TestModel" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
                                     xmlns:p1="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
                                     xmlns="http://schemas.microsoft.com/ado/2009/11/edm">
+        
         <EntityContainer Name="TestModelEntities">
-          <EntitySet Name="FirstTable" EntityType="TestModel.FirstTable" />
-          <EntitySet Name="SecondTables" EntityType="TestModel.SecondTable" />
-          <AssociationSet Name="FK_FirstTable_Order_FirstTableID" Association="TestModel.FK_FirstTable_Order_FirstTableID"/>
+          <EntitySet Name="Parent" EntityType="TestModel.Parent" />
+          <EntitySet Name="Children" EntityType="TestModel.Child" />
+          <AssociationSet Name="FK_Children_ParentId" Association="TestModel.FK_Children_ParentId">
+            <End Role="Parent" EntitySet="Parent" />
+            <End Role="Child" EntitySet="Children" />
+          </AssociationSet>
+          <AssociationSet Name="FK_Children_DerivedChildren" Association="TestModel.FK_Children_DerivedChildren">
+            <End Role="Child" EntitySet="Children" />
+            <End Role="DerivedChild" EntitySet="Children" />
+          </AssociationSet>
         </EntityContainer>
-        <EntityType Name="FirstTable">
+        
+        <EntityType Name="Parent">
           <Key>
-            <PropertyRef Name="FirstTableID" />
+            <PropertyRef Name="Id" />
           </Key>
-          <Property Name="FirstTableID" Type="Int32" Nullable="false" p1:StoreGeneratedPattern="Identity"/>
-          <Property Name="DateTimeColumn" Type="DateTime" Nullable="false"/>
+          <Property Name="Id" Type="Int32" Nullable="false" p1:StoreGeneratedPattern="Identity" />
+          <Property Name="Name" Type="String" Nullable="false" Unicode="true" />
+          <NavigationProperty Name="Children" Relationship="TestModel.FK_Children_ParentId" FromRole="Parent" ToRole="Child" />
         </EntityType>
-        <EntityType Name="SecondTable">
+          
+        <EntityType Name="Child">
           <Key>
-            <PropertyRef Name="SecondTableID" />
+            <PropertyRef Name="Id" />
           </Key>
-          <Property Name="SecondTableID" Type="Int32" Nullable="false" p1:StoreGeneratedPattern="Identity"/>
-          <Property Name="StringColumn" Type="String" Nullable="false"/>
-          <Property Name="IntegerColumn" Type="Int32"/>
-          <NavigationProperty Name="FirstTable" Relationship="TestModel.FK_FirstTable_Order_FirstTableID"/>
+          <Property Name="Id" Type="Int32" Nullable="false" p1:StoreGeneratedPattern="Identity" />
+          <Property Name="Name" Type="String" Nullable="false" Unicode="true" />
+          <Property Name="ParentId" Type="Int32" Nullable="false" />
+          <NavigationProperty Name="Parent" Relationship="TestModel.FK_Children_ParentId" FromRole="Child" ToRole="Parent" />
+          <NavigationProperty Name="DerivedChild" Relationship="TestModel.FK_Children_DerivedChildren" FromRole="Child" ToRole="DerivedChild" />
         </EntityType>
+        
+        <EntityType Name="DerivedChild" BaseType="TestModel.Child">
+          <Property Name="Description" Type="String" Nullable="false" Unicode="true" />
+          <NavigationProperty Name="Child" Relationship="TestModel.FK_Children_DerivedChildren" FromRole="DerivedChild" ToRole="Child" />
+        </EntityType>
+      
       </Schema>
     </edmx:ConceptualModels>
-    <edmx:Mappings>
+    <edmx:Mappings>     
       <Mapping Space="C-S" xmlns="http://schemas.microsoft.com/ado/2009/11/mapping/cs">
-        <EntityContainerMapping StorageEntityContainer="TestModelsStoreContainer" CdmEntityContainer="TestModelEntities">
-          <EntitySetMapping Name="FirstTable">
-            <EntityTypeMapping TypeName="TestModel.FirstTable">
-              <MappingFragment StoreEntitySet="FirstTable">
-                <ScalarProperty Name="FirstTableID" ColumnName="FirstTableID" />
-                <ScalarProperty Name="DateTimeColumn" ColumnName="DateTimeColumn" />
+        <EntityContainerMapping StorageEntityContainer="TestModelStoreContainer" CdmEntityContainer="TestModelEntities">
+          
+          <EntitySetMapping Name="Children">
+            <EntityTypeMapping TypeName="IsTypeOf(TestModel.Child)">
+              <MappingFragment StoreEntitySet="Children">
+                <ScalarProperty Name="Id" ColumnName="Id" />
+                <ScalarProperty Name="Name" ColumnName="Name" />
+                <ScalarProperty Name="ParentId" ColumnName="ParentId" />
+              </MappingFragment>
+            </EntityTypeMapping>
+            <EntityTypeMapping TypeName="IsTypeOf(TestModel.DerivedChild)">
+              <MappingFragment StoreEntitySet="DerivedChildren">
+                <ScalarProperty Name="Id" ColumnName="Id" />
+                <ScalarProperty Name="Description" ColumnName="Description" />
               </MappingFragment>
             </EntityTypeMapping>
           </EntitySetMapping>
-          <EntitySetMapping Name="SecondTables">
-            <EntityTypeMapping TypeName="TestModel.SecondTable">
-              <MappingFragment StoreEntitySet="SecondTables">
-                <ScalarProperty Name="SecondTableID" ColumnName="SecondTableID" />
-                <ScalarProperty Name="StringColumn" ColumnName="StringColumn" />
-                <ScalarProperty Name="IntegerColumn" ColumnName="IntegerColumn" />
+          
+          <EntitySetMapping Name="Parent">
+            <EntityTypeMapping TypeName="TestModel.Parent">
+              <MappingFragment StoreEntitySet="Parent">
+                <ScalarProperty Name="Id" ColumnName="Id" />
               </MappingFragment>
             </EntityTypeMapping>
           </EntitySetMapping>
+        
         </EntityContainerMapping>
       </Mapping>
     </edmx:Mappings>

--- a/Tests.Unit/Tests.Unit.csproj
+++ b/Tests.Unit/Tests.Unit.csproj
@@ -93,6 +93,7 @@
     <Compile Include="EntityDocExtension\DatabaseDocumentationSourceTests.cs" />
     <Compile Include="EntityDocExtension\Diagnostics\OutputPaneProviderTests.cs" />
     <Compile Include="EntityDocExtension\Diagnostics\OutputWindowLoggerTests.cs" />
+    <Compile Include="EntityDocExtension\EdmxFixture.cs" />
     <Compile Include="EntityDocExtension\ModelDocumentationUpdaterTests.cs" />
     <Compile Include="EntityDocExtension\ModelGenerationExtensionTests.cs" />
     <Compile Include="ErrorListAdapterTests.cs" />
@@ -113,6 +114,9 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="EntityDocExtension\TestModel.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
When table names are pluralized, they do not exactly match entity names. The actual table names should be pulled from the edmx mapping section. This resolves issue #11.