### PR TITLE
Fix scenario when config has child items.

### DIFF
--- a/extension/EFDocumentationGenerator/Utilities/ProjectExtensions.cs
+++ b/extension/EFDocumentationGenerator/Utilities/ProjectExtensions.cs
@@ -64,7 +64,6 @@ namespace DocumentationGenerator.Utilities
 		{
 			return project.ProjectItems
 			              .Cast<ProjectItem>()
-			              .Where(item => item.ProjectItems == null || item.ProjectItems.Count == 0)
 			              .SingleOrDefault(item => predicate(item));
 		}
 	}


### PR DESCRIPTION
Remove invalid restriction on project file items since configs can have child items. This fixes issue #12.